### PR TITLE
Add fallback for other architectures

### DIFF
--- a/goid.go
+++ b/goid.go
@@ -1,0 +1,7 @@
+// +build !amd64
+
+package goid
+
+func Goid() int64 {
+	return goidFallback()
+}

--- a/goid_amd64_1_9.s
+++ b/goid_amd64_1_9.s
@@ -1,4 +1,4 @@
-// +build go1.9
+// +build go1.9,amd64
 
 #include "textflag.h"
 

--- a/goid_fallback.go
+++ b/goid_fallback.go
@@ -1,0 +1,15 @@
+package goid
+
+import (
+	"bytes"
+	"runtime"
+	"strconv"
+)
+
+func goidFallback() int64 {
+	buf := make([]byte, 20)
+	buf = buf[:runtime.Stack(buf, false)]
+	goidStr := string(bytes.Split(buf, []byte(" "))[1])
+	result, _ := strconv.ParseInt(goidStr, 10, 64)
+	return result
+}

--- a/goid_test.go
+++ b/goid_test.go
@@ -1,9 +1,6 @@
 package goid
 
 import (
-	"bytes"
-	"fmt"
-	"runtime"
 	"sync"
 	"testing"
 )
@@ -13,12 +10,10 @@ func TestGoid(t *testing.T) {
 	wg.Add(10000)
 	for i := 0; i < 10000; i++ {
 		go func() {
-			buf := make([]byte, 20)
-			buf = buf[:runtime.Stack(buf, false)]
-			goidRuntime := string(bytes.Split(buf, []byte(" "))[1])
-			goidAsm := fmt.Sprintf("%d", Goid())
-			if goidRuntime != goidAsm {
-				t.Errorf("goid from runtime is %s, goid from asm is %s", goidRuntime, goidAsm)
+			goidRuntime := goidFallback()
+			goidAsm := Goid()
+			if goidAsm == 0 || goidRuntime != goidAsm {
+				t.Errorf("goid from runtime is %d, goid from asm is %d", goidRuntime, goidAsm)
 			}
 			wg.Done()
 		}()


### PR DESCRIPTION
This change adds fallback support if package is used on other architectures such as arm64.